### PR TITLE
adding VIA register using the 65222 header file to the rp6502 header

### DIFF
--- a/include/rp6502.h
+++ b/include/rp6502.h
@@ -8,6 +8,9 @@
 #ifndef _RP6502_H_
 #define _RP6502_H_
 
+#include <_6522.h>
+#define VIA (*(volatile struct __6522 *)0xFFD0)
+
 // RP6502 RIA $FFE0-$FFF9
 
 #include <stdint.h>


### PR DESCRIPTION
This creates a struct for the VIA with members for each register.
I tested it using my SNES controller reading code and was able to set the data direction for port A using VIA.ddra.